### PR TITLE
Handle tags separately

### DIFF
--- a/templates/etc/rs-collector-ng.conf.j2
+++ b/templates/etc/rs-collector-ng.conf.j2
@@ -13,7 +13,7 @@ host = "{{ _.bosun.host }}"
 [[collector.{{ name }}]]
 {% for k,v in collector_data.items() %}
 {% if k == "tags" %}
-[emitter.{{ name }}.tags]
+[collector.{{ name }}.tags]
 {% for tk,tv in v.items() -%}
 {{ tk }} = {{ tv | to_json }}
 {% endfor %}

--- a/templates/etc/rs-collector-ng.conf.j2
+++ b/templates/etc/rs-collector-ng.conf.j2
@@ -12,9 +12,15 @@ host = "{{ _.bosun.host }}"
 {% for collector_data in _[name] %}
 [[collector.{{ name }}]]
 {% for k,v in collector_data.items() %}
-{{ k }} = {{ v | to_json }}
+{% if k == "tags" %}
+[emitter.{{ name }}.tags]
+{% for tk,tv in v.items() -%}
+{{ tk }} = {{ tv | to_json }}
 {% endfor %}
-
+{% else %}
+{{ k }} = {{ v | to_json }}
+{% endif %}
+{% endfor %}
 {% endfor %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
`to_json` map values are not compatible with toml, so we extract the tags and list them in a compatible fashion

```
[[collector.jvm]]
tags = {"hello": "world"}
```

is now

```
[[collector.jvm]]
[collector.jvm.tags]
hello = "world"
```