### PR TITLE
Bosun Collector: Use FQDN for host tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     RSCOLLECTORNG:
       ...
   roles:
-    - { role: update_scollector_config, tags: [ 'scollector' ], _rs_collector_ng: "{{ RSCOLLECTORNG }}" }
+    - { role: update_rs_collector_ng_config, tags: [ 'rscollectorng' ], _rs_collector_ng: "{{ RSCOLLECTORNG }}" }
 ```
 
 ### Collectors
@@ -90,7 +90,7 @@ If the key `_rs_collector_ng.bosun` or any children are provided then the defaul
 _rs_collector_ng:
   # Bosun emitter
   bosun:
-    url: "https://user:password@hostname.example.com:8070/"
+    host: "https://user:password@hostname.example.com:8070/"
     tags: # tags are optional and can be omitted
       key: value
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,19 +1,22 @@
-S_COLLECTOR_DEFAULTS:
+S_COLLECTOR_DUMMY_VALUES:
   auth:
     user: bosun
     password: bosun
   server:
     ip: localhost
     port: 8080
-  hostname: hostname
-  hostgroup: hostgroup
+  hostname: default-host
+  domain: default-domain
+  hostgroup: default-hostgroup
   common:
     tags: {}
-S_COLLECTOR_ACTUAL: "{{ _scollector | default(S_COLLECTOR_DEFAULTS) }}"
+# Note: Dummy values are only required so that this var file does not break in absence of
+#       scollector values because the user chose to override the bosun config
+S_COLLECTOR_ACTUAL: "{{ _scollector | default(S_COLLECTOR_DUMMY_VALUES) }}"
 RS_COLLECTOR_DEFAULTS:
   bosun:
     host: "https://{{ S_COLLECTOR_ACTUAL.auth.user }}:{{ S_COLLECTOR_ACTUAL.auth.password }}@{{ S_COLLECTOR_ACTUAL.server.ip }}:{{ S_COLLECTOR_ACTUAL.server.port }}/"
-    tags: "{{ S_COLLECTOR_ACTUAL.common.tags | combine({'hostgroup': S_COLLECTOR_ACTUAL.hostgroup, 'host': S_COLLECTOR_ACTUAL.hostname}) }}"
+    tags: "{{ S_COLLECTOR_ACTUAL.common.tags | combine({'hostgroup': S_COLLECTOR_ACTUAL.hostgroup, 'host': S_COLLECTOR_ACTUAL.hostname ~ '.' ~ S_COLLECTOR_ACTUAL.domain}) }}"
   # enable postfix and rscollector by default, unless overridden by user
   postfix: [{}]
   rscollector: [{}]


### PR DESCRIPTION
Default behavior for scollector is using the FQDN https://github.com/Rheinwerk/ansible-role-update_scollector_config/blob/031f7b3a5541c24a5e546e910107276fae7a6c7f/templates/etc/bosun/scollector.conf.j2#L3 so we do the same.